### PR TITLE
Update getting-started-with-logstash.asciidoc

### DIFF
--- a/docs/static/getting-started-with-logstash.asciidoc
+++ b/docs/static/getting-started-with-logstash.asciidoc
@@ -298,7 +298,7 @@ example:
 ["source","sh",subs="attributes"]
 --------------------------------------------------
 cd logstash-{logstash_version}
-bin/logstash -e 'input { stdin { } } output { stdout {} }'
+bin/logstash -e "input { stdin { } } output { stdout {} }"
 --------------------------------------------------
 
 NOTE: The location of the `bin` directory varies by platform. See {logstash-ref}/dir-layout.html[Directory layout]


### PR DESCRIPTION
Single quotations cause errors, should be double quotes

<!-- Type of change
- bug
-->

## What does this PR do?

Update the documentation for getting started with logstash

Replaced single quotes with double quotes because single quotes cause unknown command errors

## Why is it important/What is the impact to the user?

Allows the correct command to be used and for the user to progress with getting started with Logstash

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[] I have commented my code, particularly in hard-to-understand areas~~
- ~~[] I have made corresponding changes to the documentation~~
- ~~[] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Double check syntax

## How to test this PR locally

Run the command with the double quotes through logstash